### PR TITLE
docs: add a DeepWiki badge to enable automatic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tenstorrent/tt-isa-documentation)
+
 # Tenstorrent ISA Documentation
 
 This repository contains low-level documentation about Tenstorrent AI architectures.


### PR DESCRIPTION
In order to enable automatic updates of tt-isa-documentation DeepWiki page, a badge needs to be added to the README file.